### PR TITLE
refactor: remove unused SourceLocation and sources field

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -13,7 +13,6 @@ interface Diagnostic {
   fix?: string // how to fix it
   hint?: string // additional hint
   docs?: string // documentation URL
-  sources?: SourceLocation[]
   cause?: unknown
   context?: Record<string, unknown> // machine-readable details
 }
@@ -254,7 +253,7 @@ log.NUXT_B2011({ src: pluginPath }).throw()
 ```
 src/
   index.ts              # Public API exports
-  types.ts              # Diagnostic, DiagnosticActions, SourceLocation, Formatter, Reporter, Overrides, etc.
+  types.ts              # Diagnostic, DiagnosticActions, Formatter, Reporter, Overrides, etc.
   diagnostics.ts        # defineDiagnostics() — pure data + typed factories → Diagnostic
   logger.ts             # createLogger() — binds diagnostics + formatter + reporter
   error.ts              # CodedError class
@@ -271,7 +270,7 @@ Zero runtime dependencies.
 
 ## Implementation Steps
 
-1. **`src/types.ts`** — `Diagnostic`, `DiagnosticActions`, `DiagnosticDefinition`, `MessageTemplate`, `SourceLocation`, `Formatter`, `Reporter`, `Overrides`, type utilities (`ExtractParams<T>`)
+1. **`src/types.ts`** — `Diagnostic`, `DiagnosticActions`, `DiagnosticDefinition`, `MessageTemplate`, `Formatter`, `Reporter`, `Overrides`, type utilities (`ExtractParams<T>`)
 2. **`src/diagnostics.ts`** — `defineDiagnostics({ docsBase, codes })` — typed factory functions per code, each producing plain `Diagnostic`. `docsBase` accepts a string (auto-appends code) or function (full URL control). Utility methods: `codes()`, `has()`, `get()`, `extend()`.
 3. **`src/format.ts`** — Port `wrapLine()` / `renderFrame()`. Implement `plainFormatter`.
 4. **`src/error.ts`** — `CodedError` class, constructed from a `Diagnostic` object

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ When library authors define diagnostics in one place, messages stay consistent. 
 
 Structured diagnostics enable a different kind of agent integration — **precise rather than probabilistic**.
 
-Every diagnostic has a stable code an agent can dispatch on directly, instead of pattern-matching on message text. The object carries everything needed to act: what happened (`message`), why (`why`), how to fix it (`fix`), where to learn more (`docs`), and machine-readable details (`context`, `sources`). The per-code documentation pages are equally useful for agents — they can crawl or fetch them for deeper context when the inline fields aren't enough.
+Every diagnostic has a stable code an agent can dispatch on directly, instead of pattern-matching on message text. The object carries everything needed to act: what happened (`message`), why (`why`), how to fix it (`fix`), where to learn more (`docs`), and machine-readable details (`context`). The per-code documentation pages are equally useful for agents — they can crawl or fetch them for deeper context when the inline fields aren't enough.
 
 An agent can resolve the issue without asking the user for more information. Users don't need to configure anything — if a library uses `logs-sdk`, its diagnostics are already agent-ready. All codes are defined in a catalog, so an agent can enumerate the full error surface ahead of time. And when multiple libraries in a stack adopt it, agents get uniformly structured data from every layer.
 

--- a/__snapshots__/tsnapi/index.snapshot.d.ts
+++ b/__snapshots__/tsnapi/index.snapshot.d.ts
@@ -19,7 +19,6 @@ export interface Diagnostic {
   fix?: string;
   hint?: string;
   docs?: string;
-  sources?: SourceLocation[];
   cause?: unknown;
   context?: Record<string, unknown>;
   stack?: string;
@@ -51,11 +50,6 @@ export interface LoggerMethods {
   log: (_: Diagnostic) => void;
   format: (_: Diagnostic) => string;
 }
-export interface SourceLocation {
-  file?: string;
-  line?: number;
-  column?: number;
-}
 
 // Types
 export type CodeFactory<T> = IsEmptyObject<ExtractParams<T>> extends true ? (overrides?: Overrides) => Diagnostic : (params: Simplify<ExtractParams<T>>, overrides?: Overrides) => Diagnostic;
@@ -64,7 +58,7 @@ export type DiagnosticsResult<C extends Record<string, DiagnosticDefinition>> = 
 export type Formatter = (_: Diagnostic) => string;
 export type Logger<D extends readonly any[]> = MergeFactories<D> & LoggerMethods;
 export type MergeFactories<D extends readonly any[]> = D extends readonly [infer First, ...infer Rest] ? ActionFactories<First> & MergeFactories<Rest> : {};
-export type Overrides = Partial<Pick<Diagnostic, "level" | "sources" | "cause" | "context">>;
+export type Overrides = Partial<Pick<Diagnostic, "level" | "cause" | "context">>;
 export type Reporter = (_: Diagnostic, _: string) => void;
 
 // Classes

--- a/skills/logs-sdk/SKILL.md
+++ b/skills/logs-sdk/SKILL.md
@@ -22,7 +22,6 @@ interface Diagnostic {
   fix?: string // how to resolve it
   hint?: string // additional guidance
   docs?: string // URL to documentation page for this code
-  sources?: SourceLocation[]
   cause?: unknown
   context?: Record<string, unknown>
 }
@@ -277,13 +276,12 @@ const fileReporter: Reporter = (diagnostic, formatted) => {
 When calling a factory, you can pass `Overrides` to attach runtime context:
 
 ```ts
-type Overrides = Partial<Pick<Diagnostic, 'level' | 'sources' | 'cause' | 'context'>>
+type Overrides = Partial<Pick<Diagnostic, 'level' | 'cause' | 'context'>>
 ```
 
 ```ts
 diagnostics.NUXT_B2011({ src: pluginPath }, {
   cause: originalError,
-  sources: [{ file: 'nuxt.config.ts', line: 42 }],
   context: { moduleName: 'my-module' },
 })
 ```

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -5,19 +5,6 @@ import type { ExtractParams, IsEmptyObject, Simplify } from './utils'
  */
 export type DiagnosticLevel = 'error' | 'warn' | 'suggestion' | 'deprecation'
 
-/**
- * Source location in user code. Use the `file:line:column` string convention
- * when a simpler representation suffices.
- */
-export interface SourceLocation {
-  file?: string
-  line?: number
-  column?: number
-}
-
-/**
- * A structured, serializable diagnostic object with a stable code.
- */
 export interface Diagnostic {
   /**
    * Unique, stable identifier for this diagnostic (e.g. `MATH_E001`).
@@ -48,14 +35,6 @@ export interface Diagnostic {
    * Auto-generated from {@link DefineDiagnosticsOptions.docsBase}.
    */
   docs?: string
-  /**
-   * Relevant source locations in user code associated with this diagnostic.
-   */
-  sources?: SourceLocation[]
-  /**
-   * Original error or exception that triggered this diagnostic.
-   * Propagated to {@link CodedError.cause} when throwing.
-   */
   cause?: unknown
   /**
    * Arbitrary key-value metadata for machine consumers (reporters, telemetry).
@@ -69,10 +48,7 @@ export interface Diagnostic {
   stack?: string
 }
 
-/**
- * Fields that can be overridden per-call when invoking a diagnostic factory.
- */
-export type Overrides = Partial<Pick<Diagnostic, 'level' | 'sources' | 'cause' | 'context'>>
+export type Overrides = Partial<Pick<Diagnostic, 'level' | 'cause' | 'context'>>
 
 /**
  * A template for a diagnostic text field — either a static string or a function

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ export type {
   DiagnosticsMethods,
   DiagnosticsResult,
   Overrides,
-  SourceLocation,
 } from './diagnostics'
 
 export { CodedError } from './error'


### PR DESCRIPTION
It was never used and I think it's redundant with the stacktrace which already contains this information. Also, the object wasn't needed because there's already a convention of file locations: `filepath:line:column` (which is used in stacktraces)