### PR TITLE
docs(skill): redesign logs-sdk skill as quick-start + self-contained references

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "logs-sdk",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Claude Code plugin for logs-sdk",
   "author": {
     "name": "Eduardo San Martin Morote"

--- a/skills/logs-sdk/SKILL.md
+++ b/skills/logs-sdk/SKILL.md
@@ -1,345 +1,77 @@
 ---
 name: logs-sdk
-description: "Structured diagnostic code library for JavaScript/TypeScript. Turns errors, warnings, suggestions, and deprecations into typed, machine-readable Diagnostic objects with stable codes, docs URLs, and actionable fields. Use this skill whenever the project imports `logs-sdk`, or works with `defineDiagnostics`, `createLogger`, `CodedError`, diagnostic code registries, structured error handling, or error code documentation pages. Also use when building custom formatters, reporters (consoleReporter, createFetchReporter, createFileReporter from logs-sdk/reporters/node, devReporter from logs-sdk/reporters/dev), Vite plugins (logsSDK, logsSDKServer from logs-sdk/unplugin), or integrating diagnostic codes into a library or framework."
+description: "Structured diagnostic codes for JS/TS. Use when a project imports `logs-sdk`, defines codes with `defineDiagnostics`, binds output with `createLogger`, throws `CodedError`, or wires the Vite plugins (`logsSDK`, `logsSDKServer`) / `devReporter`. Covers the quick-start, the two rules that types won't tell you (code permanence, dev-loop wiring), and points to the full API reference."
 ---
 
 # logs-sdk
 
-Structured diagnostic code library for JavaScript/TypeScript. Every error, warning, suggestion, and deprecation becomes a typed, serializable `Diagnostic` object with a stable code, docs URL, and actionable fields.
+Typed diagnostic codes → plain serializable `Diagnostic` objects → chainable actions (`.throw()`, `.error()`, `.warn()`, `.log()`, `.format()`). A `CodedError` materializes only when you call `.throw()`.
 
-## Core Concepts
-
-### Object-first design
-
-The fundamental unit is a plain `Diagnostic` object — serializable, transportable (client-server, worker-main, build tool-IDE). An `Error` class (`CodedError`) is only created at the moment `.throw()` is called.
+## Quick-start
 
 ```ts
-interface Diagnostic {
-  code: string // e.g. 'NUXT_B2011'
-  level: 'error' | 'warn' | 'suggestion' | 'deprecation'
-  message: string // human-readable, already interpolated
-  why?: string // why this happened
-  fix?: string // how to resolve it
-  hint?: string // additional guidance
-  docs?: string // URL to documentation page for this code
-  sources?: SourceLocation[]
-  cause?: unknown
-  context?: Record<string, unknown>
-}
-```
-
-### Diagnostic levels
-
-- `error` — something is broken and must be fixed
-- `warn` — something may cause issues
-- `suggestion` — an improvement the user could make
-- `deprecation` — something that will be removed in a future version
-
-## API Reference
-
-### `defineDiagnostics(options)` — Define diagnostic codes
-
-Creates typed factory functions that produce plain `Diagnostic` objects. No side effects, no logging.
-
-```ts
+// src/diagnostics.ts
 import { defineDiagnostics } from 'logs-sdk'
 
-const diagnostics = defineDiagnostics({
-  docsBase: code => `https://nuxt.com/e/${code.replace('NUXT_', '').toLowerCase()}`,
+export const diagnostics = defineDiagnostics({
+  docsBase: 'https://example.com/errors', // optional; auto-appends /${code.toLowerCase()}
   codes: {
-    NUXT_B1001: {
-      message: 'Could not compile template.',
-      fix: 'Check the template for syntax errors.',
+    MATH_E001: {
+      message: 'Division by zero',
+      fix: 'Ensure the denominator is not zero',
     },
-    NUXT_B2011: {
-      message: (p: { src: string }) => `Invalid plugin \`${p.src}\`. src option is required.`,
-      fix: 'Pass a string path or an object with a `src` property to `addPlugin()`.',
-    },
-    NUXT_B5001: {
-      message: 'Missing compatibilityDate in nuxt.config.',
-      fix: (p: { date: string }) => `Add \`compatibilityDate: '${p.date}'\` to your nuxt.config.`,
-      hint: 'This ensures consistent behavior across Nuxt versions.',
+    MATH_W001: {
+      message: (p: { n: number }) => `Negative input ${p.n} for factorial`,
+      fix: 'Ensure n is a non-negative integer',
       level: 'warn',
     },
   },
 })
 ```
 
-**Options:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `docsBase` | `string \| ((code: string) => string \| undefined)?` | Docs URL source. As a string, auto-generates `docs` as `${docsBase}/${code.toLowerCase()}`. As a function, receives the code key and returns the full URL (or `undefined` to omit). |
-| `codes` | `Record<string, DiagnosticDefinition>` | Map of code keys to their definitions |
-
-**DiagnosticDefinition fields:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `message` | `string \| (params) => string` | Required. The diagnostic message |
-| `fix` | `string \| (params) => string` | Optional. How to resolve the issue |
-| `why` | `string \| (params) => string` | Optional. Why this diagnostic was triggered |
-| `hint` | `string \| (params) => string` | Optional. Additional contextual guidance |
-| `level` | `DiagnosticLevel` | Optional. Defaults to `'error'` |
-
-**Type inference:** Parameters are extracted from ALL template fields (`message`, `fix`, `why`, `hint`) and intersected. If `message` needs `{ src }` and `fix` needs `{ date }`, the factory requires `{ src, date }`.
-
-**Factory usage:**
-
 ```ts
-// No params — factory takes optional overrides only
-diagnostics.NUXT_B1001()
-diagnostics.NUXT_B1001({ level: 'warn' })
-
-// With params — first arg is params, second is optional overrides
-diagnostics.NUXT_B2011({ src: '/plugins/bad.ts' })
-diagnostics.NUXT_B2011({ src: '/plugins/bad.ts' }, { cause: originalError })
-```
-
-**Registry methods** (non-enumerable on the result):
-
-```ts
-diagnostics.codes() // → ['NUXT_B1001', 'NUXT_B2011', 'NUXT_B5001']
-diagnostics.has('NUXT_B1001') // → true (type guard: narrows to known code key)
-diagnostics.get('NUXT_B1001') // → the raw DiagnosticDefinition
-diagnostics.extend({ // → new diagnostics set with additional codes merged in
-  NUXT_B9999: { message: 'New code.' }
-})
-```
-
-### `createLogger(options)` — Bind diagnostics to output
-
-Merges diagnostic sets and wraps each code factory to return `DiagnosticActions` — a `Diagnostic` enriched with action methods.
-
-```ts
-import { consoleReporter, createLogger, plainFormatter } from 'logs-sdk'
-import { ansiFormatter } from 'logs-sdk/formatters/ansi'
-
-const log = createLogger({
-  diagnostics: [diagnostics],
-  formatter: ansiFormatter(colors), // or plainFormatter (default)
-  reporters: consoleReporter, // default — pass a single function or an array
-})
-```
-
-**Usage:**
-
-```ts
-log.NUXT_B2011({ src: pluginPath }).throw() // formats, reports, then throws CodedError
-log.NUXT_B1001().warn() // overrides level to 'warn', formats, reports
-log.NUXT_B5001({ date: '2025-01-01' }).log() // uses the definition's level ('warn')
-log.NUXT_B1001().format() // returns the formatted string only
-
-// Raw methods for pre-built Diagnostic objects
-log.throw(diagnostics.NUXT_B2011({ src: pluginPath }))
-log.warn(diagnostics.NUXT_B1001())
-```
-
-**Multiple diagnostic sets:**
-
-```ts
-const log = createLogger({
-  diagnostics: [nuxtDiagnostics, i18nDiagnostics],
-})
-
-log.NUXT_B2011({ src: pluginPath }).throw() // [NUXT_B2011] ...
-log.I18N_I001({ locale: 'fr' }).warn() // [I18N_I001] ...
-```
-
-### `CodedError` — Error class
-
-Created only when `.throw()` is called. Extends `Error` with `name: 'CodedError'`.
-
-```ts
-class CodedError extends Error {
-  readonly diagnostic: Diagnostic // the full object
-}
-```
-
-The `message` is formatted as `[CODE] message text`. Access all diagnostic fields via `err.diagnostic`.
-
-**Catch and inspect:**
-
-```ts
-try {
-  log.NUXT_B2011({ src: pluginPath }).throw()
-}
-catch (err) {
-  if (err instanceof CodedError) {
-    console.log(err.diagnostic.code) // 'NUXT_B2011'
-    console.log(err.diagnostic.docs) // 'https://nuxt.com/e/b2011'
-    console.log(err.diagnostic.fix) // 'Pass a string path...'
-  }
-}
-```
-
-### Formatters
-
-All are plain functions: `(d: Diagnostic) => string`.
-
-| Formatter | Import | Description |
-|-----------|--------|-------------|
-| `plainFormatter` | `logs-sdk` | Unicode box-drawing, no colors. Default. |
-| `ansiFormatter(colors)` | `logs-sdk/formatters/ansi` | Accepts a generic `Colors` interface — no hard ANSI dependency |
-| `jsonFormatter` | `logs-sdk/formatters/json` | `JSON.stringify(diagnostic)` |
-
-**ANSI formatter `Colors` interface:**
-
-```ts
-interface Colors {
-  red: (s: string) => string
-  yellow: (s: string) => string
-  cyan: (s: string) => string
-  gray: (s: string) => string
-  bold: (s: string) => string
-  dim: (s: string) => string
-}
-```
-
-**Plain formatter output:**
-
-```
-[NUXT_B2011] Invalid plugin `/plugins/bad.ts`. src option is required.
-├▶ why: The plugin object was passed without a src path
-├▶ fix: Pass a string path or an object with a `src` property to `addPlugin()`.
-├▶ hint: Check your module's addPlugin() calls
-╰▶ see: https://nuxt.com/e/b2011
-```
-
-Detail line order is fixed: `why` → `fix` → `hint` → `see` (docs URL). Missing fields are omitted.
-
-**Writing a custom formatter:**
-
-```ts
-import type { Formatter } from 'logs-sdk'
-
-const myFormatter: Formatter = (d) => {
-  return `[${d.code}] ${d.message}${d.fix ? ` (fix: ${d.fix})` : ''}`
-}
-```
-
-### Formatting utilities
-
-Two lower-level functions are exported for building custom formatters:
-
-- `formatTag(d: Diagnostic)` — returns the `[CODE]` tag string (e.g. `[NUXT_B2011]` for code `'NUXT_B2011'`)
-- `renderFrame(d: Diagnostic)` — returns the full box-drawing formatted string (same as `plainFormatter`)
-
-### Reporters
-
-All are plain functions: `(d: Diagnostic, formatted: string) => void`. Pass a single reporter or an array.
-
-| Reporter | Import | Description |
-|----------|--------|-------------|
-| `consoleReporter` | `logs-sdk` | `console.error` for `'error'` level, `console.warn` for all others |
-| `createFetchReporter(url)` | `logs-sdk` | POSTs diagnostic JSON to the given URL (silently ignores fetch errors) |
-| `createFileReporter(options?)` | `logs-sdk/reporters/node` | Appends diagnostics as NDJSON to a local file (default `.diagnostics.log`) |
-| `devReporter` | `logs-sdk/reporters/dev` | Sends diagnostics to the Vite dev server via `import.meta.hot.send()` for dev-time collection |
-
-**File reporter usage:**
-
-```ts
-import { createFileReporter } from 'logs-sdk/reporters/node'
-
-const log = createLogger({
-  diagnostics: [diagnostics],
-  reporters: [consoleReporter, createFileReporter()],
-})
-
-// Or with a custom path:
-createFileReporter({ logFile: 'my-app.log' })
-```
-
-**Dev reporter usage:**
-
-```ts
+// src/logger.ts
 import { consoleReporter, createLogger } from 'logs-sdk'
-import { devReporter } from 'logs-sdk/reporters/dev'
+import { diagnostics } from './diagnostics'
 
-const log = createLogger({
-  diagnostics: [diagnostics],
-  reporters: [consoleReporter, devReporter],
-})
+export const log = createLogger({ diagnostics: [diagnostics] })
 ```
 
-**Writing a custom reporter:**
-
 ```ts
-import type { Reporter } from 'logs-sdk'
+// src/math.ts
+import { log } from './logger'
 
-const fileReporter: Reporter = (diagnostic, formatted) => {
-  fs.appendFileSync('errors.log', `${formatted}\n`)
+export function divide(a: number, b: number) {
+  if (b === 0) log.MATH_E001().throw() // [MATH_E001] Division by zero
+  return a / b
+}
+export function factorial(n: number) {
+  if (n < 0) log.MATH_W001({ n }).warn()
+  return n <= 1 ? 1 : n * factorial(n - 1)
 }
 ```
 
-### Overrides
+TypeScript enforces params; factories are cmd+clickable. Full API (formatters, reporters, custom formatters, `docsBase` as a function, multiple diagnostic sets) lives in the root `README.md`.
 
-When calling a factory, you can pass `Overrides` to attach runtime context:
+## Two rules types won't tell you
 
-```ts
-type Overrides = Partial<Pick<Diagnostic, 'level' | 'sources' | 'cause' | 'context'>>
-```
+**1. Codes are permanent.** Once published, never reuse or reassign a code — downstream users and agents search by code, link to `docs` pages by code, and dispatch on code strings. Renaming `MATH_E001` breaks every hit.
 
-```ts
-diagnostics.NUXT_B2011({ src: pluginPath }, {
-  cause: originalError,
-  sources: [{ file: 'nuxt.config.ts', line: 42 }],
-  context: { moduleName: 'my-module' },
-})
-```
+Convention: `PREFIX_XNNNN` where `X` groups by domain — e.g. `B`=build, `R`=runtime, `C`=config, `E`=error, `W`=warn, `D`=deprecation. Pick a scheme and stick to it. Use the `/add-diagnostic` skill to add a new code following the convention.
 
-## Vite Plugins
+**2. `fix` is the field agents act on.** Always fill it when the resolution is known — it's the most valuable field for both humans and AI. `why` explains non-obvious causes; `hint` adds supplementary guidance.
 
-Two unplugin-based plugins for build-time optimization and dev-time diagnostic collection, imported from `logs-sdk/unplugin`.
+## Dev loop — tree-shake from prod, capture in dev
 
-### `logsSDK` — Build-time AST transform
+`logs-sdk/unplugin` exposes two plugins that work together:
 
-Marks `defineDiagnostics()` and `createLogger()` calls as `/*#__PURE__*/` and wraps diagnostic usage with a `NODE_ENV` guard so diagnostics tree-shake out of production builds. Supports `.vite()`, `.webpack()`, `.rollup()`, etc. via unplugin.
-
-```ts
-import { logsSDK } from 'logs-sdk/unplugin'
-
-export default defineConfig({
-  plugins: [
-    logsSDK.vite(),
-  ],
-})
-```
-
-**Options (`LogsSdkPluginOptions`):**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `packageName` | `string?` | The package name to detect imports from. Default: `'logs-sdk'` |
-
-### `logsSDKServer` — Dev server diagnostic collector
-
-Listens for diagnostics sent over the Vite WebSocket (from `devReporter` in the browser) and writes them as NDJSON to a local log file via `createFileReporter`. Vite-only.
-
-```ts
-import { logsSDKServer } from 'logs-sdk/unplugin'
-
-export default defineConfig({
-  plugins: [
-    logsSDKServer.vite(),
-  ],
-})
-```
-
-**Options (`LogsSdkServerOptions`):**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `logFile` | `string?` | Path to the log file. Default: `'.diagnostics.log'` |
-| `debug` | `boolean?` | Enable debug logging for the plugin. Default: `!!process.env.DEBUG` |
-
-### Typical dev setup
-
-Use both plugins together with `devReporter` for full dev-time diagnostic capture:
+- `logsSDK.vite()` — AST-marks `defineDiagnostics()`/`createLogger()` calls as `/*#__PURE__*/` and wraps diagnostic usage with a `NODE_ENV` guard, so prod builds tree-shake diagnostic code out entirely.
+- `logsSDKServer.vite()` — listens on the Vite WS for diagnostics from the browser (sent by `devReporter`) and writes them as NDJSON to `.diagnostics.log` for the agent to read.
 
 ```ts
 // vite.config.ts
 import { logsSDK, logsSDKServer } from 'logs-sdk/unplugin'
+import { defineConfig } from 'vite'
 
 export default defineConfig({
   plugins: [logsSDK.vite(), logsSDKServer.vite()],
@@ -350,6 +82,7 @@ export default defineConfig({
 // src/logger.ts
 import { consoleReporter, createLogger } from 'logs-sdk'
 import { devReporter } from 'logs-sdk/reporters/dev'
+import { diagnostics } from './diagnostics'
 
 export const log = createLogger({
   diagnostics: [diagnostics],
@@ -357,40 +90,13 @@ export const log = createLogger({
 })
 ```
 
-## Best Practices
+## References
 
-### Code naming conventions
+Read these on-demand when the task calls for them — they are self-contained and don't require the repo or README.
 
-- Use fully qualified, stable code identifiers (e.g. `NUXT_B1001`, `I18N_I001`)
-- Group by domain using a letter prefix within the code: `B` for build, `R` for runtime, `C` for config, etc.
-- Never reuse or reassign a code once published — codes are permanent identifiers
-
-### Structuring diagnostic definitions
-
-- Always provide `message` — it is the only required field
-- Provide `fix` whenever the solution is known — this is the most actionable field for both humans and AI agents
-- Provide `why` to explain root causes when the reason may not be obvious from the message alone
-- Use `hint` for supplementary guidance that doesn't fit in `fix` (e.g. links to related docs, edge cases)
-- Set the appropriate `level` — default is `'error'`, override to `'warn'`, `'suggestion'`, or `'deprecation'` as needed
-- Use parameterized templates for messages that include runtime values — avoid string concatenation outside the factory
-
-### Organizing diagnostic files
-
-For large projects, split diagnostics by domain:
-
-```
-src/
-  diagnostics/
-    build.ts       # NUXT_B-series codes
-    runtime.ts     # NUXT_R-series codes
-    config.ts      # NUXT_C-series codes
-    index.ts       # re-exports and merges all sets
-```
-
-Each file calls `defineDiagnostics()` with the same `docsBase` but different code ranges.
-
-## Documentation Site
-
-For guidance on building error code documentation pages (structure, templates, deployment, and AI-agent optimization), read `references/documentation-site.md`.
+- `references/api-reference.md` — full public surface: `Diagnostic` fields, `Overrides`, all formatters (`plainFormatter`, `ansiFormatter`, `jsonFormatter`), all reporters (`consoleReporter`, `createFetchReporter`, `createFileReporter`, `devReporter`), `CodedError`, registry methods (`codes()`/`has()`/`get()`/`extend()`), raw logger methods, `captureStack`, unplugin options.
+- `references/testing.md` — asserting diagnostics in tests: the collector-reporter pattern, `instanceof CodedError`, asserting on structured fields (not formatted strings), testing the registry itself.
+- `references/migration.md` — converting existing `throw new Error` / `console.warn` sites to `logs-sdk`: picking the right level, parameterizing messages, preserving `cause`, incremental adoption.
+- `references/documentation-site.md` — building the per-code docs pages that `docs:` URLs resolve to: page template, AI-agent-friendly structure, CI sync with `diagnostics.codes()`.
 
 <!-- synced-sha: 7c2392fb4716118fa84b469b01c7eff2c057221e -->

--- a/skills/logs-sdk/references/api-reference.md
+++ b/skills/logs-sdk/references/api-reference.md
@@ -1,0 +1,302 @@
+# API Reference
+
+Complete public surface of `logs-sdk`. The quick-start in `SKILL.md` covers the common path; this file covers the rest.
+
+## `Diagnostic` — the plain object
+
+```ts
+interface Diagnostic {
+  code: string                        // 'MATH_E001'
+  level: 'error' | 'warn' | 'suggestion' | 'deprecation'
+  message: string                     // already interpolated
+  why?: string                        // root cause / rationale
+  fix?: string                        // how to resolve
+  hint?: string                       // supplementary guidance
+  docs?: string                       // URL; auto-generated from docsBase
+  sources?: SourceLocation[]          // { file?, line?, column? }
+  cause?: unknown                     // original error, propagated to CodedError.cause
+  context?: Record<string, unknown>   // machine-only metadata; not rendered
+  stack?: string                      // auto-captured unless captureStack: false
+}
+```
+
+Diagnostics are serializable — safe to `JSON.stringify`, send across workers/processes, persist, replay. A `CodedError` is only constructed when you call `.throw()`.
+
+## `defineDiagnostics(options)`
+
+```ts
+import { defineDiagnostics } from 'logs-sdk'
+
+const diagnostics = defineDiagnostics({
+  docsBase: 'https://example.com/errors', // string | (code) => string | undefined
+  codes: {
+    MATH_E001: { message: 'Division by zero', fix: '...' },
+    MATH_W001: {
+      message: (p: { n: number }) => `Negative input ${p.n}`,
+      fix: 'Ensure n is non-negative',
+      level: 'warn',
+    },
+  },
+})
+```
+
+**`docsBase`**
+
+- String: `docs = \`${docsBase}/${code.toLowerCase()}\``
+- Function: `docs = docsBase(code)`; return `undefined` to omit the URL for that code
+- Omitted: `docs` is undefined on every diagnostic
+
+**`DiagnosticDefinition` fields**
+
+| Field     | Type                           | Notes                                  |
+| --------- | ------------------------------ | -------------------------------------- |
+| `message` | `string \| (params) => string` | Required.                              |
+| `fix`     | `string \| (params) => string` | The field agents act on. Fill it when known. |
+| `why`     | `string \| (params) => string` | Root cause; useful when non-obvious.    |
+| `hint`    | `string \| (params) => string` | Supplementary guidance.                 |
+| `level`   | `DiagnosticLevel`              | Defaults to `'error'`.                  |
+
+**Param inference** — TypeScript extracts the `params` type from **every** template field that is a function, then intersects them. If `message` needs `{ src }` and `fix` needs `{ date }`, the factory requires `{ src, date }`. No function templates → the factory takes only an optional `Overrides` argument.
+
+### Factory calls
+
+```ts
+diagnostics.MATH_E001()                            // no params
+diagnostics.MATH_E001({ level: 'warn' })           // overrides only
+diagnostics.MATH_W001({ n: -3 })                   // params
+diagnostics.MATH_W001({ n: -3 }, { cause: err })   // params + overrides
+```
+
+**`Overrides`** — per-call fields attached to the produced `Diagnostic`:
+
+```ts
+type Overrides = Partial<Pick<Diagnostic, 'level' | 'sources' | 'cause' | 'context'>>
+```
+
+### Registry methods (non-enumerable)
+
+```ts
+diagnostics.codes()          // string[] — all registered codes
+diagnostics.has('MATH_E001') // type guard: narrows to known key
+diagnostics.get('MATH_E001') // raw DiagnosticDefinition
+diagnostics.extend({ MATH_E002: { message: '...' } }) // returns a new merged set
+```
+
+## `createLogger(options)`
+
+Binds diagnostic sets to a formatter + reporters, and exposes chainable actions on each code.
+
+```ts
+import { consoleReporter, createLogger, plainFormatter } from 'logs-sdk'
+
+const log = createLogger({
+  diagnostics: [nuxtDiagnostics, i18nDiagnostics], // one or many; codes merged
+  formatter: plainFormatter,                       // default; one function
+  reporters: consoleReporter,                      // default; function or array
+  captureStack: true,                              // default; set false to disable
+})
+```
+
+| Option         | Type                                           | Default            |
+| -------------- | ---------------------------------------------- | ------------------ |
+| `diagnostics`  | `DiagnosticsResult[]`                          | required           |
+| `formatter`    | `(d: Diagnostic) => string`                    | `plainFormatter`   |
+| `reporters`    | `Reporter \| Reporter[]`                       | `consoleReporter`  |
+| `captureStack` | `boolean`                                      | `true`             |
+
+**Merging code collisions.** `diagnostics` is processed in order; if two sets share a code, the later set wins. Namespace with prefixes (`NUXT_*`, `I18N_*`) to avoid this.
+
+### Actions on each code
+
+`log.CODE(...)` returns a `DiagnosticActions` — the `Diagnostic` fields plus five methods:
+
+```ts
+log.MATH_E001().throw()                        // format → report → throw CodedError (never returns)
+log.MATH_W001({ n: -3 }).warn()                // forces level 'warn', formats, reports
+log.MATH_E001().error()                        // forces level 'error', formats, reports
+log.MATH_W001({ n: -3 }).log()                 // uses the diagnostic's own level
+log.MATH_E001().format()                       // returns formatted string, no side effect
+```
+
+### Raw methods on the logger
+
+For pre-built `Diagnostic` objects (e.g. received over the wire):
+
+```ts
+log.throw(diag)
+log.error(diag)
+log.warn(diag)
+log.log(diag)
+log.format(diag)
+```
+
+### `captureStack`
+
+When `true` (default), action methods capture a stack trace at the call site and attach it as `diagnostic.stack`. `node_modules/` frames and internal Node frames are filtered out. Disable (`captureStack: false`) in hot paths where the cost matters.
+
+## `CodedError`
+
+Constructed only by `.throw()`.
+
+```ts
+class CodedError extends Error {
+  readonly name: 'CodedError'
+  readonly message: string       // `[CODE] message`
+  readonly diagnostic: Diagnostic
+  readonly cause?: unknown       // mirrors diagnostic.cause
+}
+```
+
+```ts
+try {
+  log.MATH_E001().throw()
+}
+catch (err) {
+  if (err instanceof CodedError) {
+    err.diagnostic.code  // 'MATH_E001'
+    err.diagnostic.docs  // 'https://example.com/errors/math_e001'
+    err.diagnostic.fix   // 'Ensure the denominator is not zero'
+  }
+}
+```
+
+## Formatters
+
+A formatter is any `(d: Diagnostic) => string`.
+
+| Formatter        | Import                      | Behavior                                                        |
+| ---------------- | --------------------------- | --------------------------------------------------------------- |
+| `plainFormatter` | `logs-sdk`                  | Unicode box-drawing, no colors. Default.                        |
+| `ansiFormatter`  | `logs-sdk/formatters/ansi`  | Takes a `Colors` interface; no hard ANSI dependency.            |
+| `jsonFormatter`  | `logs-sdk/formatters/json`  | `JSON.stringify(diagnostic)`.                                   |
+
+**Plain output** (detail order is fixed: `why` → `fix` → `hint` → `see`; missing fields omitted):
+
+```
+[MATH_E001] Division by zero
+├▶ fix: Ensure the denominator is not zero
+╰▶ see: https://example.com/errors/math_e001
+```
+
+**ANSI** — inject any color lib (picocolors, kleur, chalk):
+
+```ts
+import picocolors from 'picocolors'
+import { ansiFormatter } from 'logs-sdk/formatters/ansi'
+
+interface Colors {
+  red: (s: string) => string
+  yellow: (s: string) => string
+  cyan: (s: string) => string
+  gray: (s: string) => string
+  bold: (s: string) => string
+  dim: (s: string) => string
+}
+
+const formatter = ansiFormatter(picocolors) // picocolors matches the shape
+```
+
+Level colors: `error` → red, `warn`/`deprecation` → yellow, `suggestion` → cyan.
+
+**Building your own.** Two lower-level helpers are exported for reuse:
+
+```ts
+import { formatTag, renderFrame } from 'logs-sdk'
+// formatTag(d)     → '[MATH_E001]'
+// renderFrame(d)   → the full plain box-drawing string
+
+import type { Formatter } from 'logs-sdk'
+const myFormatter: Formatter = d => `${d.code}: ${d.message}${d.fix ? ` → ${d.fix}` : ''}`
+```
+
+## Reporters
+
+A reporter is any `(d: Diagnostic, formatted: string) => void`. Pass one or an array.
+
+| Reporter                   | Import                       | Behavior                                                         |
+| -------------------------- | ---------------------------- | ---------------------------------------------------------------- |
+| `consoleReporter`          | `logs-sdk`                   | `console.error` for `'error'`, `console.warn` for everything else. |
+| `createFetchReporter(url)` | `logs-sdk`                   | POSTs `JSON.stringify(diagnostic)` to `url`. Swallows fetch errors. |
+| `createFileReporter(opts?)` | `logs-sdk/reporters/node`   | Appends NDJSON to a local file. Default path `.diagnostics.log`. |
+| `devReporter`              | `logs-sdk/reporters/dev`     | Sends over Vite HMR (`import.meta.hot.send`). See dev loop in `SKILL.md`. |
+
+**File reporter:**
+
+```ts
+import { createFileReporter } from 'logs-sdk/reporters/node'
+
+createFileReporter()                         // -> .diagnostics.log
+createFileReporter({ logFile: 'errors.log' })
+```
+
+**Custom reporter:**
+
+```ts
+import type { Reporter } from 'logs-sdk'
+
+const sentryReporter: Reporter = (diagnostic, formatted) => {
+  sentry.captureMessage(formatted, { tags: { code: diagnostic.code, level: diagnostic.level } })
+}
+```
+
+## Vite / unplugin — `logs-sdk/unplugin`
+
+Two plugins. Both support `.vite() / .rollup() / .webpack() / .rspack() / .esbuild() / .rolldown()` via [unplugin](https://unplugin.unjs.io).
+
+### `logsSDK`
+
+Build-time AST transform. Marks `defineDiagnostics()` and `createLogger()` calls as `/*#__PURE__*/` and wraps diagnostic action calls with a `NODE_ENV !== 'production'` guard — prod bundlers drop the calls entirely, achieving tree-shaking of diagnostic code.
+
+```ts
+import { logsSDK } from 'logs-sdk/unplugin'
+
+export default defineConfig({ plugins: [logsSDK.vite()] })
+```
+
+| Option        | Type     | Default       | Notes                                                        |
+| ------------- | -------- | ------------- | ------------------------------------------------------------ |
+| `packageName` | `string` | `'logs-sdk'`  | Change if re-exporting logs-sdk under a vendor package name. |
+
+### `logsSDKServer`
+
+Vite-only. Listens on the Vite WebSocket for diagnostics sent by `devReporter` (from the browser) and appends them to a local NDJSON file for an agent to read.
+
+```ts
+import { logsSDKServer } from 'logs-sdk/unplugin'
+
+export default defineConfig({ plugins: [logsSDKServer.vite()] })
+```
+
+| Option    | Type      | Default                 | Notes                                                             |
+| --------- | --------- | ----------------------- | ----------------------------------------------------------------- |
+| `logFile` | `string`  | `.diagnostics.log`      | Resolved against `server.config.root`; file is created on startup. |
+| `debug`   | `boolean` | `!!process.env.DEBUG`   | Logs each received diagnostic to the Vite server logger.           |
+
+## Exports — quick index
+
+```ts
+// Main
+import {
+  defineDiagnostics, createLogger,
+  consoleReporter, createFetchReporter,
+  plainFormatter, formatTag, renderFrame,
+  CodedError,
+} from 'logs-sdk'
+import type {
+  Diagnostic, DiagnosticLevel, DiagnosticDefinition,
+  DefineDiagnosticsOptions, CodeFactory, DiagnosticsResult, DiagnosticsMethods,
+  Overrides, SourceLocation,
+  CreateLoggerOptions, Logger, LoggerMethods, DiagnosticActions, MergeFactories,
+  Formatter, Reporter,
+} from 'logs-sdk'
+
+// Subpaths
+import { ansiFormatter, type Colors } from 'logs-sdk/formatters/ansi'
+import { jsonFormatter } from 'logs-sdk/formatters/json'
+import { createFileReporter, type FileReporterOptions } from 'logs-sdk/reporters/node'
+import { devReporter } from 'logs-sdk/reporters/dev'
+import {
+  logsSDK, logsSDKServer,
+  type LogsSdkPluginOptions, type LogsSdkServerOptions,
+} from 'logs-sdk/unplugin'
+```

--- a/skills/logs-sdk/references/documentation-site.md
+++ b/skills/logs-sdk/references/documentation-site.md
@@ -1,203 +1,113 @@
-# Documentation Site and Error Code Registry
+# Error Code Documentation Pages
 
-## Table of Contents
+Every published diagnostic code should have a dedicated page at the URL its `docs` field resolves to. Humans land there from the `see:` link in terminal output; agents fetch it to explain an error they've been handed.
 
-- [Why a documentation site matters](#why-a-documentation-site-matters)
-- [Setting up docsBase](#setting-up-docsbase)
-- [Documentation page structure](#documentation-page-structure)
-- [Page template](#page-template)
-- [Deployment recommendations](#deployment-recommendations)
-- [Keeping docs in sync with code](#keeping-docs-in-sync-with-code)
-- [Optimizing for AI agent consumption](#optimizing-for-ai-agent-consumption)
-
-## Why a documentation site matters
-
-Every diagnostic code should have a dedicated, publicly accessible documentation page. This serves three audiences:
-
-1. **Developers** encountering the error in their terminal or logs can click the `see:` URL and get immediate guidance
-2. **AI agents** (Claude, Copilot, etc.) can fetch the page content to provide contextual help when a user pastes an error
-3. **Search engines** index these pages so developers searching for `NUXT_B2011` find the answer directly
-
-## Setting up docsBase
-
-The `docsBase` option in `defineDiagnostics()` controls the auto-generated `docs` URL. It can be a string or a function:
-
-```ts
-// Function form — full control over the URL
-const diagnostics = defineDiagnostics({
-  docsBase: code => `https://nuxt.com/e/${code.replace('NUXT_', '').toLowerCase()}`,
-  codes: {
-    NUXT_B2011: { message: '...' },
-  },
-})
-// diagnostics.NUXT_B2011().docs → 'https://nuxt.com/e/b2011'
-```
-
-```ts
-// String form — code appended automatically as ${docsBase}/${code.toLowerCase()}
-const diagnostics = defineDiagnostics({
-  docsBase: 'https://example.com/errors',
-  codes: {
-    MY_E001: { message: '...' },
-  },
-})
-// diagnostics.MY_E001().docs → 'https://example.com/errors/my_e001'
-```
-
-Plan your URL structure accordingly.
-
-## Documentation page structure
-
-Each error code page (e.g. `https://nuxt.com/e/b2011`) should follow this structure. The content must be both human-readable and optimized for AI agent consumption — use clear headings, concise language, and structured sections.
-
-### Required sections
-
-**Title and code identifier**
-
-```markdown
-# NUXT_B2011: Invalid plugin — src option is required
-
-Code: `NUXT_B2011`
-Level: error
-```
-
-Start with the code and a short human-readable title. Include the code and the severity level.
-
-**What this error means**
-
-```markdown
-## What this error means
-
-This error occurs when a plugin is registered via `addPlugin()` without providing a
-valid `src` path. Nuxt requires every plugin to have a source file so it can be
-resolved and included in the build.
-```
-
-Explain the error in plain language. Assume the reader has no prior context — describe what the system expected vs what it received. This section is the primary content AI agents will use to explain the error to users.
-
-**Why this happens**
-
-```markdown
-## Why this happens
-
-Common causes:
-
-- Passing an object to `addPlugin()` without a `src` property
-- Passing `undefined` or `null` as the plugin path
-- A module is constructing a plugin object dynamically and the `src` field is missing
-  due to a conditional branch or typo
-```
-
-List the concrete scenarios that trigger this diagnostic. Use bullet points. Each bullet should be a specific, recognizable situation the developer might be in.
-
-**How to fix it**
-
-```markdown
-## How to fix it
-
-Ensure every call to `addPlugin()` includes a valid `src` path:
-
-\```ts
-// Wrong
-addPlugin({ name: 'my-plugin' })
-
-// Correct
-addPlugin({ src: resolve('./runtime/my-plugin'), name: 'my-plugin' })
-
-// Also correct — pass a string directly
-addPlugin(resolve('./runtime/my-plugin'))
-\```
-
-If the plugin path is computed dynamically, verify the variable is defined before
-passing it to `addPlugin()`.
-```
-
-Provide concrete code examples showing the wrong pattern and the corrected version. This is the most important section — it should be copy-pasteable.
-
-### Optional sections
-
-**Additional context**
-
-```markdown
-## Additional context
-
-- This validation was added in Nuxt 3.2
-- If you are writing a Nuxt module, see the [Module Author Guide](https://nuxt.com/docs/guide/going-further/modules)
-- Related codes: [NUXT_B1001](./nuxt_b1001) (template compilation), [NUXT_B3005](./nuxt_b3005) (module resolution)
-```
-
-Link to related documentation, changelog entries, or related diagnostic codes.
-
-**Example diagnostic output**
-
-```markdown
-## Example output
-
-\```
-[NUXT_B2011] Invalid plugin `/plugins/bad.ts`. src option is required.
-├▶ why: The plugin object was passed without a src path
-├▶ fix: Pass a string path or an object with a `src` property to `addPlugin()`.
-├▶ hint: Check your module's addPlugin() calls
-╰▶ see: https://nuxt.com/e/b2011
-\```
-```
-
-Show what the user actually sees in their terminal so they can confirm they're on the right page.
+For `docsBase` setup (string vs function form), see `api-reference.md`. This file covers the *content* behind those URLs.
 
 ## Page template
 
-Use this template for each error code page:
-
 ```markdown
-# {CODE}: {Short title}
+# {CODE}: {short title}
 
 Code: `{CODE}`
-Level: {error|warn|suggestion|deprecation}
+Level: {error | warn | suggestion | deprecation}
 
 ## What this error means
 
-{Plain-language explanation of the diagnostic. 1-3 sentences.}
+{Plain-language explanation. 1–3 sentences. Describe what the system expected
+vs what it received. This is the primary section AI agents read.}
 
 ## Why this happens
 
-{Bulleted list of concrete scenarios that trigger this diagnostic.}
+- {Concrete scenario 1}
+- {Concrete scenario 2}
+- {Concrete scenario 3}
 
 ## How to fix it
 
-{Code examples showing the wrong pattern and the corrected version.}
+\`\`\`ts
+// Wrong
+...
 
-## Additional context
+// Correct
+...
+\`\`\`
 
-{Links to related docs, changelog, or related diagnostic codes. Optional.}
+{Short prose after the snippet if a pattern needs explanation.}
+
+## Related
+
+- {Links to related codes, changelog entries, or guides. Optional.}
 
 ## Example output
 
-{Terminal output showing the formatted diagnostic. Optional.}
+\`\`\`
+[{CODE}] {message}
+├▶ fix: {fix}
+╰▶ see: {URL}
+\`\`\`
+
+{Optional — helps users confirm they're on the right page.}
 ```
 
-## Deployment recommendations
+## Section guidance
 
-Host the error code pages on a public URL that matches your `docsBase`:
+**Title + code block.** Start with the code and a short title. Repeat the code and level below as a machine-readable header — agents and search engines latch onto this.
 
-- **GitHub Pages or static site generator** (VitePress, Nuxt Content, etc.) — create a directory of markdown files, one per code, with a catch-all route at `/e/[code].md`
-- **Dedicated `/errors` or `/e` route** in your existing documentation site
-- Ensure pages return proper HTTP status codes (200 for valid codes, 404 for unknown codes) so agents and crawlers can distinguish valid codes from missing ones
-- Use `<meta>` tags or frontmatter for structured data (code, level, title) to improve agent and search engine consumption
-- Keep pages lightweight — avoid heavy JavaScript or SPAs that block content rendering for fetch-based agents
+**What this error means.** Plain prose. Assume zero prior context. Describe expected vs actual. No code here — keep it narrative. This is the section an agent paraphrases to the user.
+
+**Why this happens.** Bulleted concrete scenarios the developer might be in. Avoid abstractions — "passing `undefined`", "a conditional branch that forgets to set `src`", not "invalid input handling". Recognizable triggers, not taxonomy.
+
+**How to fix it.** Copy-pasteable code. Show the wrong pattern and the corrected one side by side. This section is the payload — agents often skip directly here. Prefer showing over telling.
+
+**Related / Example output.** Optional. Use "Related" for links to adjacent codes or deeper docs. Use "Example output" so users can eyeball the terminal text they're seeing and confirm they're on the right page.
+
+## Deployment
+
+Host at a URL that matches your `docsBase`. VitePress, Nuxt Content, Astro, or any static site generator works — one markdown file per code under `/e/[code].md` (or the equivalent).
+
+Non-negotiable:
+- Pages render in plain HTML without JavaScript. Agents using `fetch`-based tools will not execute scripts, and neither will most crawlers.
+- Unknown codes return 404, not 200. Agents distinguish "valid code I couldn't find docs for" from "docs are missing" via status.
+- The code string appears in the page title and in the body. Keyword search is how users arrive.
+
+Nice to have:
+- Frontmatter (`code`, `level`, `title`) for structured consumption.
+- An index page listing every code with its message and level.
+
+## Optimizing for AI-agent consumption
+
+When an agent fetches the docs URL, it's usually because the inline `fix` wasn't enough. Write so the agent can extract the action without ambiguity:
+
+- Consistent heading hierarchy — `##` for sections, never jump levels.
+- Fix instructions **early**. If an agent stops reading after the first two sections, it should still have the fix.
+- No collapsed sections, tabs, or JS-rendered content hiding critical info.
+- Self-contained code examples. An agent should be able to suggest the fix from the page content alone — don't require "see linked repo for setup".
+- Echo the code string in headings and body. Exact-match matters for both agents and search.
 
 ## Keeping docs in sync with code
 
-- Store documentation markdown alongside your diagnostic definitions or in a dedicated `docs/errors/` directory
-- Generate an index page listing all codes with their messages and levels
-- In CI, validate that every code in `defineDiagnostics()` has a corresponding documentation page — fail the build if a page is missing
-- When adding a new diagnostic code, add the documentation page in the same PR
+The code registry is authoritative. A diagnostic without a docs page produces a broken `see:` link; a docs page without a code is noise. Enforce the invariant in CI:
 
-## Optimizing for AI agent consumption
+```ts
+// scripts/check-docs.ts
+import { readdirSync, existsSync } from 'node:fs'
+import { diagnostics } from '../src/diagnostics'
 
-Pages should be structured so that an AI agent fetching the URL can extract the relevant information without ambiguity:
+const docsDir = new URL('../docs/e/', import.meta.url).pathname
+const missing: string[] = []
 
-- Use consistent heading hierarchy (`##` for sections)
-- Put the most actionable content (fix instructions) early
-- Avoid hiding critical information in collapsed sections, tabs, or JavaScript-rendered content
-- Include the code in the page title and body so keyword matching works
-- Keep code examples self-contained — an agent should be able to suggest the fix from the page content alone
+for (const code of diagnostics.codes()) {
+  const page = `${docsDir}${code.toLowerCase()}.md`
+  if (!existsSync(page)) missing.push(code)
+}
+
+if (missing.length) {
+  console.error(`Missing docs pages:\n${missing.map(c => `  - ${c}`).join('\n')}`)
+  process.exit(1)
+}
+```
+
+Add a reverse check too — every docs page should correspond to a known code (`diagnostics.has(code)`), so deleting a code from the registry flags its stale doc.
+
+Add new codes and their docs page in the same PR. The `/add-diagnostic` skill (if installed) handles this flow.

--- a/skills/logs-sdk/references/migration.md
+++ b/skills/logs-sdk/references/migration.md
@@ -1,0 +1,93 @@
+# Migration — from `throw new Error` / `console.warn` to `logs-sdk`
+
+Mechanical recipe for converting existing error and warning sites to structured diagnostics.
+
+## Mapping existing call sites
+
+| Existing                                | Replace with                                        |
+| --------------------------------------- | --------------------------------------------------- |
+| `throw new Error(msg)`                  | `log.CODE().throw()` (level defaults to `'error'`)  |
+| `throw new Error(msg, { cause })`       | `log.CODE({ ...params }, { cause }).throw()`        |
+| `console.error(msg)`                    | `log.CODE().error()`                                |
+| `console.warn(msg)`                     | `log.CODE().warn()` (or define with `level: 'warn'` → `.log()`) |
+| `console.warn('deprecated: ...')`       | Define with `level: 'deprecation'` → `.log()`       |
+| `console.info('tip: ...')`              | Define with `level: 'suggestion'` → `.log()`        |
+| `console.log('...')` for user guidance  | Define appropriate level → `.log()`                 |
+| Raw `console.log` for debugging         | **Not a diagnostic.** Leave it as `console.log`.    |
+
+Reserve diagnostics for things the user/agent needs to notice or act on. Internal debugging noise doesn't belong in the code registry.
+
+## Picking the level
+
+- **`error`** — broken; the program can't continue or the operation produced no valid result.
+- **`warn`** — a problem the caller should see but the operation continued (degraded result, fallback used).
+- **`deprecation`** — the API works but will be removed. Pair with a `fix` pointing to the replacement.
+- **`suggestion`** — not a problem at all; an improvement the user could make.
+
+If you can't decide between `error` and `warn`, ask: *does the calling code still produce a usable result?* Yes → `warn`. No → `error`.
+
+## Converting dynamic messages
+
+Interpolated strings become parameterized templates. The function form gives you typed params, keeps interpolation at one site, and lets the test suite assert on structured fields instead of message text.
+
+```ts
+// Before
+throw new Error(`Invalid plugin \`${src}\`. src option is required.`)
+
+// After — in diagnostics.ts
+NUXT_B2011: {
+  message: (p: { src: string }) => `Invalid plugin \`${p.src}\`. src option is required.`,
+  fix: 'Pass a string path or an object with a `src` property to `addPlugin()`.',
+},
+
+// After — at the call site
+log.NUXT_B2011({ src }).throw()
+```
+
+**When a value is useful but doesn't belong in the message**, put it in `context` — machine-only metadata that reporters and agents see but formatters don't render:
+
+```ts
+log.NUXT_B2011({ src }, { context: { moduleName, resolvedFrom } }).throw()
+```
+
+## Preserving the original error
+
+Wrap with `cause`. The `CodedError` thrown by `.throw()` mirrors it onto `Error.cause`, so existing `err.cause` consumers keep working.
+
+```ts
+// Before
+try { await parse(x) } catch (err) {
+  throw new Error(`Parse failed: ${err.message}`, { cause: err })
+}
+
+// After
+try { await parse(x) } catch (err) {
+  log.PARSE_E001({ input: x }, { cause: err }).throw()
+}
+```
+
+## Incremental adoption
+
+You don't need to convert the whole codebase at once. Three staged approaches, cheapest first:
+
+**1. One domain at a time.** Add a new diagnostics file per domain (`build.ts`, `runtime.ts`, `config.ts`), each calling `defineDiagnostics()`. Combine them in `createLogger({ diagnostics: [...] })`. Convert call sites in that domain, leave the rest alone. No downstream break — the rest still throws regular `Error`s.
+
+**2. Wrap at the boundary.** If a deep internal function throws `Error`, catch it at the next higher layer and re-throw via a diagnostic with `cause`. You structure the public surface without touching the internals.
+
+```ts
+try {
+  return internalParse(src)
+}
+catch (err) {
+  log.PARSE_E001({ src }, { cause: err }).throw()
+}
+```
+
+**3. Keep both in parallel (rare).** If a call site is on the critical path and you're nervous about changing its behavior, call `.error()`/`.warn()` *and* keep the existing `throw`/`console` call for one release. Remove the old call once consumers have migrated their catch/assertion code. Don't leave both in long-term — pick one.
+
+## Don't forget
+
+- **Codes are permanent** — once shipped, never rename or reassign. If a diagnostic's meaning genuinely changes, introduce a new code and deprecate the old one.
+- **Fill `fix`** whenever the resolution is known. It's the single most-valuable field for humans and agents.
+- **Set `docsBase`** from day one, even before the docs pages exist. Codes will start surfacing `docs:` URLs immediately, and you can fill in the pages behind them incrementally. See `documentation-site.md`.
+- **Add new codes in a PR that also adds the docs page** — the `/add-diagnostic` skill guides this workflow if installed.

--- a/skills/logs-sdk/references/testing.md
+++ b/skills/logs-sdk/references/testing.md
@@ -1,0 +1,170 @@
+# Testing Diagnostics
+
+How to assert that the right diagnostics fire, without coupling tests to formatter output. Examples use Vitest; Jest is equivalent.
+
+## Assert on structured fields, not formatted strings
+
+A diagnostic is a plain object with a stable `code`. Assert on that. Formatted strings change when you swap formatters or tweak wording; the code never should.
+
+```ts
+// ❌ brittle — breaks when the message wording changes
+expect(stderr).toContain('Division by zero')
+
+// ✅ stable — the code is the contract
+expect(err.diagnostic.code).toBe('MATH_E001')
+```
+
+## Testing `.throw()`
+
+`.throw()` raises a `CodedError`. Use `toThrow` with the class, then catch to inspect fields.
+
+```ts
+import { expect, it } from 'vitest'
+import { CodedError } from 'logs-sdk'
+import { divide } from '../src/math'
+
+it('throws MATH_E001 on division by zero', () => {
+  expect(() => divide(1, 0)).toThrow(CodedError)
+
+  try {
+    divide(1, 0)
+  }
+  catch (err) {
+    if (!(err instanceof CodedError)) throw err
+    expect(err.diagnostic.code).toBe('MATH_E001')
+    expect(err.diagnostic.level).toBe('error')
+    expect(err.diagnostic.fix).toMatch(/denominator/i)
+  }
+})
+```
+
+## Testing `.warn()` / `.error()` / `.log()`
+
+These don't throw — they format and hand off to reporters. To observe them in tests, swap the logger's reporters for a collector.
+
+### The collector pattern
+
+Export a `makeTestLogger` (or similar) from a test helper. It builds a logger that pushes every diagnostic into an array you can assert on.
+
+```ts
+// test/helpers/logger.ts
+import { createLogger, type Reporter, type Diagnostic } from 'logs-sdk'
+import { diagnostics } from '../../src/diagnostics'
+
+export function makeTestLogger() {
+  const collected: Diagnostic[] = []
+  const collect: Reporter = d => void collected.push(d)
+  const log = createLogger({
+    diagnostics: [diagnostics],
+    reporters: collect,
+    captureStack: false, // stable snapshots, cheaper
+  })
+  return { log, collected }
+}
+```
+
+Wire it into the code under test via dependency injection, or by re-exporting from the module that owns the logger and overriding in tests (see below).
+
+### Assert that a specific code fired
+
+```ts
+import { expect, it } from 'vitest'
+import { makeTestLogger } from './helpers/logger'
+
+it('warns MATH_W001 on negative factorial input', () => {
+  const { log, collected } = makeTestLogger()
+  factorial(-3, { log })
+
+  expect(collected).toHaveLength(1)
+  expect(collected[0]).toMatchObject({
+    code: 'MATH_W001',
+    level: 'warn',
+  })
+  expect(collected[0].message).toContain('-3')
+})
+```
+
+### Assert a code did **not** fire
+
+```ts
+it('does not warn on valid factorial input', () => {
+  const { log, collected } = makeTestLogger()
+  factorial(5, { log })
+
+  expect(collected.every(d => d.code !== 'MATH_W001')).toBe(true)
+})
+```
+
+### Assert overrides were applied
+
+Per-call overrides (`cause`, `context`, `sources`) land on the diagnostic. Assert on them when the behavior matters.
+
+```ts
+it('attaches the original error as cause', () => {
+  const { log, collected } = makeTestLogger()
+  runWithError(log)
+
+  expect(collected[0].cause).toBeInstanceOf(TypeError)
+  expect(collected[0].context).toMatchObject({ requestId: 'abc-123' })
+})
+```
+
+## Stubbing console in integration tests
+
+When you can't inject a logger (it's a singleton deep in the code), spy on the console instead. `consoleReporter` routes `'error'` → `console.error` and everything else → `console.warn`.
+
+```ts
+import { afterEach, expect, it, vi } from 'vitest'
+
+afterEach(() => vi.restoreAllMocks())
+
+it('warns on deprecated sum()', () => {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  sum(1, 2)
+  expect(warn).toHaveBeenCalledOnce()
+  expect(warn.mock.calls[0][0]).toContain('[MATH_D001]') // the tag is stable
+})
+```
+
+Asserting on the `[CODE]` tag is safer than asserting on the full message — the tag format is part of the public contract; message wording is not.
+
+## Snapshotting formatter output
+
+If you *do* want to snapshot formatter output (e.g. to catch unintended wording changes), disable stack capture so snapshots don't churn across environments:
+
+```ts
+const log = createLogger({
+  diagnostics: [diagnostics],
+  reporters: (_d, formatted) => snapshot.push(formatted),
+  captureStack: false,
+})
+```
+
+## Testing diagnostic definitions themselves
+
+`defineDiagnostics()` is pure — you can call factories directly, no logger needed.
+
+```ts
+import { expect, it } from 'vitest'
+import { diagnostics } from '../src/diagnostics'
+
+it('MATH_W001 interpolates n into the message', () => {
+  const d = diagnostics.MATH_W001({ n: -7 })
+  expect(d.code).toBe('MATH_W001')
+  expect(d.message).toContain('-7')
+  expect(d.level).toBe('warn')
+})
+
+it('all codes have a fix or a hint', () => {
+  for (const code of diagnostics.codes()) {
+    const def = diagnostics.get(code)
+    expect(def.fix ?? def.hint, `${code} missing fix/hint`).toBeDefined()
+  }
+})
+
+it('docs URL is stable for MATH_E001', () => {
+  expect(diagnostics.MATH_E001().docs).toBe('https://example.com/errors/math_e001')
+})
+```
+
+The last pattern — iterating `diagnostics.codes()` and asserting invariants — is a cheap, high-value test for catching drift as the code registry grows.


### PR DESCRIPTION
## Summary

- **`SKILL.md`: 396 → 102 lines.** Now a quick-start recipe (define → logger → throw/warn) plus the two rules types won't surface: code permanence (`PREFIX_XNNNN`, never reassign) and the dev loop (`logsSDK.vite()` + `logsSDKServer.vite()` + `devReporter`). Everything else moved to references.
- **Self-contained references.** The published package ships only `dist/` + `skills/`, so agents invoking the skill through the installed package can't read the repo's `README.md`. Added:
  - `references/api-reference.md` — full public surface (`Diagnostic`, `Overrides`, all formatters/reporters, `CodedError`, registry methods, raw logger methods, `captureStack`, unplugin options).
  - `references/testing.md` — collector-reporter pattern, `instanceof CodedError`, asserting structured fields over formatted strings, registry invariant tests.
  - `references/migration.md` — `throw new Error` / `console.warn` → `logs-sdk`, level picking, `cause` propagation, incremental adoption paths.
  - `references/documentation-site.md` — trimmed (dropped TOC, dropped duplicated `docsBase` content that now lives in api-reference), leads with the page template, adds a concrete CI sync snippet using `diagnostics.codes()`.
- **Plugin bumped to 0.0.4** per `AGENTS.md`.

## Why

The old `SKILL.md` was a 400-line API reference — most of it duplicated what TypeScript types and JSDoc already surface, and it pointed agents at files (`README.md`, `demo-lib/`, `playground/`) that aren't in the published tarball. The skill was both bloated and broken for its primary audience: agents in a downstream project that only has `node_modules/logs-sdk/` to work from.

The redesign puts the high-signal content (non-obvious rules, canonical setup) in the always-loaded `SKILL.md` and pushes the rest behind progressive-disclosure references that are fully self-contained.

## Test plan

- [ ] Skill triggers on `import { defineDiagnostics } from 'logs-sdk'` in a downstream project.
- [ ] An agent following the `SKILL.md` quick-start alone can produce a working `diagnostics.ts` + `logger.ts` + call site.
- [ ] An agent pointed at `references/testing.md` can write a passing vitest test asserting a specific code fired.
- [ ] `references/api-reference.md` covers every export in `src/index.ts` and each subpath in `package.json` `exports`.
- [ ] The CI snippet in `references/documentation-site.md` runs against the demo-lib diagnostics registry (`diagnostics.codes()` enumerates all codes).