### PR TITLE
feat: per-code `docs` to override or opt out of `docsBase`

### DIFF
--- a/__snapshots__/tsnapi/index.snapshot.d.ts
+++ b/__snapshots__/tsnapi/index.snapshot.d.ts
@@ -14,6 +14,7 @@ export interface DiagnosticCallParams {
 export interface DiagnosticDefinition<P = any> {
   why: ValueOrFn<string, P>;
   fix?: ValueOrFn<string, P>;
+  docs?: string | false;
 }
 export interface DiagnosticHandle<Params, ReporterOpts> {
   report: (..._: ActionArgs<Params, ReporterOpts>) => Diagnostic;

--- a/src/diagnostic.test-d.ts
+++ b/src/diagnostic.test-d.ts
@@ -161,6 +161,38 @@ describe('defineDiagnostics — params inference', () => {
   })
 })
 
+describe('defineDiagnostics — per-code docs', () => {
+  it('accepts `docs: string` on a code definition', () => {
+    defineDiagnostics({
+      codes: { X: { why: 'msg', docs: 'https://example.com/x' } },
+    })
+  })
+
+  it('accepts `docs: false` on a code definition', () => {
+    defineDiagnostics({
+      codes: { X: { why: 'msg', docs: false } },
+    })
+  })
+
+  it('rejects `docs: true` on a code definition', () => {
+    defineDiagnostics({
+      codes: {
+        // @ts-expect-error: docs must be a string or false
+        X: { why: 'msg', docs: true },
+      },
+    })
+  })
+
+  it('rejects non-string/non-false on docs', () => {
+    defineDiagnostics({
+      codes: {
+        // @ts-expect-error: docs must be a string or false
+        X: { why: 'msg', docs: 42 },
+      },
+    })
+  })
+})
+
 describe('defineDiagnostics — return types', () => {
   it('.report returns Diagnostic', () => {
     const errs = defineDiagnostics({ codes: { X: { why: 'msg' } } })

--- a/src/diagnostic.test.ts
+++ b/src/diagnostic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   defineDiagnostics,
   Diagnostic,
+  formatDiagnostic,
   reporterError,
   reporterLog,
   reporterRequiredOptions,
@@ -209,6 +210,27 @@ describe('built-in reporters', () => {
     ).toHaveBeenErrored()
   })
 
+  it('omits the `see:` line when docsBase is undefined', () => {
+    const errs = defineDiagnostics({ codes: { X: { why: 'boom' } } })
+    expect(formatDiagnostic(errs.X.report())).toBe('[X] boom')
+  })
+
+  it('omits the `see:` line when a code opts out with `docs: false`', () => {
+    const errs = defineDiagnostics({
+      docsBase: 'https://example.com/errors',
+      codes: { X: { why: 'boom', docs: false } },
+    })
+    expect(formatDiagnostic(errs.X.report())).toBe('[X] boom')
+  })
+
+  it('includes the `see:` line when docs is set', () => {
+    const errs = defineDiagnostics({
+      docsBase: 'https://example.com/errors',
+      codes: { X: { why: 'boom' } },
+    })
+    expect(formatDiagnostic(errs.X.report())).toBe('[X] boom\n╰▶ see: https://example.com/errors/x')
+  })
+
   it('reporterRequiredOptions includes the code and the priority value', () => {
     const errs = defineDiagnostics({
       codes: { NUXT_E001: { why: 'boom' } },
@@ -264,6 +286,31 @@ describe('defineDiagnostics', () => {
     it('leaves Diagnostic.docs undefined when docsBase is omitted', () => {
       const errs = defineDiagnostics({ codes: { X: { why: 'msg' } } })
       expect(errs.X.report().docs).toBeUndefined()
+    })
+
+    it('per-code `docs: false` opts out of docsBase', () => {
+      const errs = defineDiagnostics({
+        docsBase: 'https://example.com/errors',
+        codes: { X: { why: 'no docs', docs: false } },
+      })
+      expect(errs.X.report().docs).toBeUndefined()
+    })
+
+    it('per-code `docs: string` overrides docsBase', () => {
+      const errs = defineDiagnostics({
+        docsBase: 'https://example.com/errors',
+        codes: {
+          X_001: { why: 'overridden', docs: 'https://custom.example/foo' },
+        },
+      })
+      expect(errs.X_001.report().docs).toBe('https://custom.example/foo')
+    })
+
+    it('per-code `docs: string` works without docsBase', () => {
+      const errs = defineDiagnostics({
+        codes: { X: { why: 'msg', docs: 'https://custom.example/foo' } },
+      })
+      expect(errs.X.report().docs).toBe('https://custom.example/foo')
     })
   })
 

--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -32,6 +32,14 @@ export interface DiagnosticDefinition<P = any> {
    * ```
    */
   fix?: ValueOrFn<string, P>
+
+  /**
+   * Per-code docs URL. A string overrides
+   * {@link DefineDiagnosticsOptions.docsBase} for this code; `false` opts this
+   * code out entirely, even when `docsBase` is set. When omitted, the URL is
+   * derived from `docsBase`.
+   */
+  docs?: string | false
 }
 
 /**
@@ -359,8 +367,12 @@ export function defineDiagnostics<
 
   for (const code of Object.keys(options.codes) as Extract<keyof Codes, string>[]) {
     const def = options.codes[code]
+    // skip docs if set to false, otherwise use it or derive it from docsBase
     const docs
-      = typeof docsBase === 'string' ? `${docsBase}/${code.toLowerCase()}` : docsBase?.(code)
+      = def.docs === false
+        ? undefined
+        : def.docs
+          || (typeof docsBase === 'string' ? `${docsBase}/${code.toLowerCase()}` : docsBase?.(code))
 
     const handle = {
       report(


### PR DESCRIPTION
Adds `docs?: string | false` to `DiagnosticDefinition` — a string overrides `docsBase` for that code, `false` opts the code out entirely.