### PR TITLE
docs: sync skills with v0.1.0 API surface

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nostics",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "Claude Code plugin for nostics",
   "author": {
     "name": "Eduardo San Martin Morote"

--- a/skills/add-diagnostic/SKILL.md
+++ b/skills/add-diagnostic/SKILL.md
@@ -33,6 +33,7 @@ CODE_NAME: {
   // OR with parameters:
   why: (p: { paramName: string }) => `Template with ${p.paramName}.`,
   fix: 'How to resolve the issue.', // optional but recommended
+  docs: 'https://example.com/custom-page', // optional — overrides docsBase, or `false` to opt out
 },
 ```
 
@@ -43,6 +44,7 @@ Rules:
 - Always provide `fix` when the solution is known
 - Use typed arrow functions for parameterized templates: `(p: { key: Type }) => string`
 - Runtime fields (`cause`, `sources`) are passed at the call site, not in the definition
+- `docs?: string | false` overrides `docsBase` for this code, or opts out entirely with `false`
 
 ## Step 4: Call the Code
 

--- a/skills/nostics/SKILL.md
+++ b/skills/nostics/SKILL.md
@@ -67,10 +67,26 @@ const diagnostics = defineDiagnostics({
 
 **DiagnosticDefinition fields:**
 
-| Field | Type                           | Description                                             |
-| ----- | ------------------------------ | ------------------------------------------------------- |
-| `why` | `string \| (params) => string` | Required. Why this failed. Becomes the `Error.message`. |
-| `fix` | `string \| (params) => string` | Optional. How to resolve the issue.                     |
+| Field  | Type                           | Description                                                                                                  |
+| ------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `why`  | `string \| (params) => string` | Required. Why this failed. Becomes the `Error.message`.                                                      |
+| `fix`  | `string \| (params) => string` | Optional. How to resolve the issue.                                                                          |
+| `docs` | `string \| false`              | Optional. Per-code docs URL override. `string` replaces `docsBase` for this code; `false` opts out entirely. |
+
+**Per-code docs override:**
+
+```ts
+codes: {
+  NUXT_B2011: {
+    why: 'message',
+    docs: 'https://nuxt.com/custom/b2011', // overrides docsBase for this code
+  },
+  NUXT_W9001: {
+    why: 'message',
+    docs: false, // opts out — no `see:` line rendered
+  },
+}
+```
 
 **Type inference:** Parameters from all template fields (`why`, `fix`) are intersected. If `why` needs `{ src }` and `fix` needs `{ date }`, the call site requires `{ src, date }`.
 

--- a/skills/nostics/references/documentation-site.md
+++ b/skills/nostics/references/documentation-site.md
@@ -27,7 +27,7 @@ The `docsBase` option in `defineDiagnostics()` controls the auto-generated `docs
 const diagnostics = defineDiagnostics({
   docsBase: (code) => `https://nuxt.com/e/${code.replace('NUXT_', '').toLowerCase()}`,
   codes: {
-    NUXT_B2011: { message: '...' },
+    NUXT_B2011: { why: '...' },
   },
 })
 // diagnostics.NUXT_B2011().docs → 'https://nuxt.com/e/b2011'
@@ -38,7 +38,7 @@ const diagnostics = defineDiagnostics({
 const diagnostics = defineDiagnostics({
   docsBase: 'https://example.com/errors',
   codes: {
-    MY_E001: { message: '...' },
+    MY_E001: { why: '...' },
   },
 })
 // diagnostics.MY_E001().docs → 'https://example.com/errors/my_e001'


### PR DESCRIPTION
## Summary

- Document the per-code `docs` field (`string | false`) in `skills/nostics/SKILL.md` and `skills/add-diagnostic/SKILL.md` so agents learn the override / opt-out behavior added in #10.
- Fix two stale `message:` examples in `skills/nostics/references/documentation-site.md` that should read `why:` (the field has always been `why`).
- Bump `.claude-plugin/plugin.json` from `0.0.5` to `0.1.0` to track the package release, per the `AGENTS.md` rule on plugin versions.

## Test plan

- [x] `eslint --fix` on changed files via pre-commit `lint-staged` (passed)
- [ ] Skim rendered Markdown on the PR to confirm the table and example blocks lay out correctly