### PR TITLE
feat: filter stack frames in file reporter

### DIFF
--- a/src/code-transform/server-plugin.ts
+++ b/src/code-transform/server-plugin.ts
@@ -1,4 +1,5 @@
 import type { UnpluginInstance } from 'unplugin'
+import type { FileReporterOptions } from '../reporters/node'
 import { existsSync, writeFileSync } from 'node:fs'
 import { relative, resolve } from 'node:path'
 import { createUnplugin } from 'unplugin'
@@ -16,6 +17,13 @@ export interface NosticsServerOptions {
    * @default !!process.env.DEBUG
    */
   debug?: boolean
+
+  /**
+   * Stack frames matching ANY of these patterns are removed from each
+   * diagnostic's stack trace before it is written to the log file.
+   * Forwarded to {@link createFileReporter}.
+   */
+  excludeStackFrames?: readonly RegExp[]
 }
 
 export const nosticsServer: UnpluginInstance<NosticsServerOptions | undefined> = createUnplugin(
@@ -24,7 +32,11 @@ export const nosticsServer: UnpluginInstance<NosticsServerOptions | undefined> =
     const debug = options?.debug ?? !!process.env.DEBUG
     // eslint-disable-next-line no-console -- debug logging opt-in
     const log = debug ? (...args: unknown[]) => console.log('[nostics]', ...args) : () => {}
-    const reporter = createFileReporter({ logFile })
+    const reporterOptions: FileReporterOptions = {
+      logFile,
+      excludeStackFrames: options?.excludeStackFrames,
+    }
+    const reporter = createFileReporter(reporterOptions)
 
     return {
       name: 'nostics-server',

--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -258,30 +258,6 @@ const captureStackTrace = (
   Error as { captureStackTrace?: (target: object, frame: Function) => void }
 ).captureStackTrace
 
-/**
- * Strips `node_modules` and Node internal frames from a raw stack string. The
- * header line (`Error: ...`) and any non-frame lines are preserved as-is.
- */
-function cleanStack(raw: string): string {
-  const lines = raw.split('\n')
-  return (
-    lines
-      /**
-       * NOTE: shorter version of the code below
-       * if (!line.trimStart().startsWith('at ')) {
-       *   return true
-       * }
-       * return !line.includes('/node_modules/') && !line.includes('(node:')
-       */
-      .filter(
-        line =>
-          !line.trimStart().startsWith('at ')
-          || (!line.includes('/node_modules/') && !line.includes('(node:')),
-      )
-      .join('\n')
-  )
-}
-
 export class Diagnostic extends Error {
   name: string = 'Diagnostic'
 
@@ -325,8 +301,6 @@ export class Diagnostic extends Error {
     // scenario, we fall back to the stack `Error` captures by default, which
     // includes a couple of extra internal frames but is still usable.
     captureStackTrace?.(this, captureFrom)
-    if (this.stack)
-      this.stack = cleanStack(this.stack)
   }
 
   /**

--- a/src/reporters/node.test.ts
+++ b/src/reporters/node.test.ts
@@ -53,4 +53,30 @@ describe('createFileReporter', () => {
     expect(() => diagnostics.E1()).not.toThrow()
     expect('Failed to write log').toHaveBeenErrored()
   })
+
+  it('includes the stack in the NDJSON payload', () => {
+    const diagnostics = defineDiagnostics({
+      codes: { E1: { why: 'msg' } },
+      reporters: [createFileReporter({ logFile })],
+    })
+    diagnostics.E1()
+    const entry = JSON.parse(readFileSync(logFile, 'utf8').trim())
+    expect(typeof entry.stack).toBe('string')
+    expect(entry.stack).toContain('node.test.ts')
+  })
+
+  it('excludeStackFrames drops frames matching any pattern', () => {
+    const diagnostics = defineDiagnostics({
+      codes: { E1: { why: 'msg' } },
+      reporters: [
+        createFileReporter({
+          logFile,
+          excludeStackFrames: [/node.test\.ts/],
+        }),
+      ],
+    })
+    diagnostics.E1()
+    const entry = JSON.parse(readFileSync(logFile, 'utf8').trim())
+    expect(entry.stack).not.toContain('node.test.ts')
+  })
 })

--- a/src/reporters/node.ts
+++ b/src/reporters/node.ts
@@ -1,4 +1,4 @@
-import type { DiagnosticReporter } from '../diagnostic'
+import type { Diagnostic, DiagnosticReporter } from '../diagnostic'
 import { appendFileSync } from 'node:fs'
 
 export interface FileReporterOptions {
@@ -7,11 +7,26 @@ export interface FileReporterOptions {
    * @default '.nostics.log'
    */
   logFile?: string
+
+  /**
+   * Stack frames matching ANY of these patterns are removed from
+   * `diagnostic.stack` before it is written to the log file. Useful to strip
+   * `node_modules` and Node internals. The `Error: ...` header line is
+   * always preserved.
+   */
+  excludeStackFrames?: readonly RegExp[]
+}
+
+function applyExcludeStackFrames(raw: string, exclude: readonly RegExp[]): string {
+  const [header, ...frames] = raw.split('\n')
+  return [header, ...frames.filter(frame => !exclude.some(re => re.test(frame)))].join('\n')
 }
 
 /**
  * Creates a reporter that appends diagnostics as NDJSON to a local file.
- * Each diagnostic is written as a single JSON line.
+ * Each diagnostic is written as a single JSON line. The diagnostic's `stack`
+ * (if present) is included in the payload; noisy frames can be removed via
+ * {@link FileReporterOptions.excludeStackFrames}.
  *
  * @example
  * ```ts
@@ -20,15 +35,26 @@ export interface FileReporterOptions {
  *
  * const diagnostics = defineDiagnostics({
  *   codes: { ... },
- *   reporters: [createFileReporter()],
+ *   reporters: [createFileReporter({
+ *     excludeStackFrames: [/\/node_modules\//, /\(node:/],
+ *   })],
  * })
  * ```
  */
 export function createFileReporter(options?: FileReporterOptions): DiagnosticReporter {
   const logFile = options?.logFile ?? '.nostics.log'
+  const excludeStackFrames = options?.excludeStackFrames
   return (diagnostic) => {
     try {
-      appendFileSync(logFile, `${JSON.stringify(diagnostic)}\n`)
+      const d = diagnostic as Diagnostic & Record<string, unknown>
+      const base: Record<string, unknown>
+        = typeof d.toJSON === 'function' ? (d.toJSON() as Record<string, unknown>) : { ...d }
+      if (d.stack) {
+        base.stack = excludeStackFrames?.length
+          ? applyExcludeStackFrames(d.stack, excludeStackFrames)
+          : d.stack
+      }
+      appendFileSync(logFile, `${JSON.stringify(base)}\n`)
     }
     catch (err: unknown) {
       console.error(`[nostics]: Failed to write log to "${logFile}":`, err)


### PR DESCRIPTION
## Summary
- Drop the hard-coded `node_modules`/`(node:` filter from the `Diagnostic` constructor; stacks captured at runtime are now raw (only the constructor frame is stripped via `Error.captureStackTrace`).
- `createFileReporter` includes `diagnostic.stack` in the NDJSON payload and gains an `excludeStackFrames?: readonly RegExp[]` option to drop matching frames before writing. Header line is always preserved.
- `nosticsServer` accepts and forwards `excludeStackFrames` so stacks coming over `nostics:report` get cleaned at the log-write boundary instead of at capture time.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run` (115 passing)
- [ ] Manual: configure `nosticsServer({ excludeStackFrames: [/\/node_modules\//, /\(node:/] })` and confirm `.nostics.log` entries have clean stacks.